### PR TITLE
chore: dependency maintenance 2026-05-23 (Spring Boot 4.1.0-RC1, Spring AI 2.0.0-M7)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,12 +12,12 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Set up Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: liberica
           java-version: ${{ matrix.java }}
       - name: Cache local Maven repository
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}

--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -16,4 +16,4 @@
 # under the License.
 wrapperVersion=3.3.2
 distributionType=only-script
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.9/apache-maven-3.9.9-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.16/apache-maven-3.9.16-bin.zip

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ This application:
 ### Prerequisites
 
 - Java SDK 25
-- Maven 3.9.9
+- Maven 3.9.16
 - OpenAI or Groq Cloud API key
 
 ### Clone

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -9,7 +9,7 @@
 - **Spring AI 2.x** - LLM integration with support for multiple providers
 - **Apache POI 5.x** - Excel (.xlsx) file generation
 - **OpenCSV 5.x** - CSV file parsing and validation
-- **Maven 3.9.9** - Build and dependency management
+- **Maven 3.9.16** - Build and dependency management
 
 ### Frontend
 

--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -8,7 +8,7 @@ Before building the project, ensure you have the following installed:
 
 - **Git CLI** - For cloning the repository
 - **Java SDK 25** - [Download from Oracle](https://www.oracle.com/java/technologies/downloads/#java25) or use [SDKMAN](https://sdkman.io/)
-- **Maven 3.9.9** - [Download from Apache Maven](https://maven.apache.org/download.cgi)
+- **Maven 3.9.16** - [Download from Apache Maven](https://maven.apache.org/download.cgi)
 
 ### Optional
 
@@ -164,7 +164,7 @@ java -version
 # Should show Java 25
 
 mvn -version
-# Should show Maven 3.9.9 or later
+# Should show Maven 3.9.16 or later
 ```
 
 ## Dependencies Overview

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -18,7 +18,7 @@ The CI workflow is defined in `.github/workflows/ci.yml` and runs on:
 - **Runner:** Ubuntu latest
 - **Java Version:** 25
 - **Java Distribution:** Liberica
-- **Maven Version:** 3.9.9
+- **Maven Version:** 3.9.16
 
 ### CI Pipeline Steps
 

--- a/pom.xml
+++ b/pom.xml
@@ -113,6 +113,10 @@
 			<groupId>org.springframework.ai</groupId>
 			<artifactId>spring-ai-starter-model-openai</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-starter-model-ollama</artifactId>
+		</dependency>
 
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -50,17 +50,17 @@
 		<java.version>25</java.version>
 		<!-- Skip git-commit-id plugin when .git is unavailable (e.g., Docker builds) -->
 		<skip.git.info>false</skip.git.info>
-		<assertj.version>3.27.6</assertj.version>
+		<assertj.version>3.27.7</assertj.version>
 		<cfenv.version>3.5.0</cfenv.version>
-		<jackson-databind-nullable.version>0.2.8</jackson-databind-nullable.version>
+		<jackson-databind-nullable.version>0.2.10</jackson-databind-nullable.version>
 		<jakarta-validation.version>3.1.1</jakarta-validation.version>
-		<json-io.version>4.70.0</json-io.version>
+		<json-io.version>4.102.0</json-io.version>
 		<node.version>v24.12.0</node.version>
 		<npm.version>11.7.0</npm.version>
 		<poi.version>5.5.1</poi.version>
 		<spring-ai.version>2.0.0-M7</spring-ai.version>
-		<spring-doc.version>3.0.1</spring-doc.version>
-		<spring-boot-hc5.version>2.0.0</spring-boot-hc5.version>
+		<spring-doc.version>3.0.3</spring-doc.version>
+		<spring-boot-hc5.version>2.0.1</spring-boot-hc5.version>
 		<spring-cloud-bindings.version>2.0.4</spring-cloud-bindings.version>
 	</properties>
 
@@ -205,7 +205,7 @@
 			<dependency>
 				<groupId>org.springframework.cloud</groupId>
 				<artifactId>spring-cloud-dependencies</artifactId>
-				<version>2025.1.0</version>
+				<version>2025.1.1</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>
@@ -267,7 +267,7 @@
 			<plugin>
 				<groupId>org.openapitools</groupId>
 				<artifactId>openapi-generator-maven-plugin</artifactId>
-				<version>7.18.0</version>
+				<version>7.22.0</version>
 				<executions>
 					<execution>
 						<goals>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>4.0.1</version>
+		<version>4.1.0-RC1</version>
 		<relativePath/>
 		<!-- lookup parent from repository -->
 	</parent>
@@ -58,7 +58,7 @@
 		<node.version>v24.12.0</node.version>
 		<npm.version>11.7.0</npm.version>
 		<poi.version>5.5.1</poi.version>
-		<spring-ai.version>2.0.0-M1</spring-ai.version>
+		<spring-ai.version>2.0.0-M7</spring-ai.version>
 		<spring-doc.version>3.0.1</spring-doc.version>
 		<spring-boot-hc5.version>2.0.0</spring-boot-hc5.version>
 		<spring-cloud-bindings.version>2.0.4</spring-cloud-bindings.version>
@@ -154,10 +154,6 @@
 			<version>${spring-cloud-bindings.version}</version>
 		</dependency>
 		<dependency>
-			<groupId>org.springframework.ai</groupId>
-			<artifactId>spring-ai-spring-cloud-bindings</artifactId>
-		</dependency>
-		<dependency>
 			<groupId>io.github.springboot-addons</groupId>
 			<artifactId>spring-boot-starter-httpclient5-actuator</artifactId>
 			<version>${spring-boot-hc5.version}</version>
@@ -215,13 +211,6 @@
 				<version>4.4.0</version>
 				<scope>import</scope>
 				<type>pom</type>
-			</dependency>
-			<dependency>
-				<groupId>io.micrometer</groupId>
-				<artifactId>micrometer-bom</artifactId>
-				<version>1.16.1</version>
-				<type>pom</type>
-				<scope>import</scope>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>
@@ -393,5 +382,16 @@
 			</snapshots>
 		</repository>
 	</repositories>
+
+	<pluginRepositories>
+		<pluginRepository>
+			<id>spring-milestones</id>
+			<name>Spring Milestones</name>
+			<url>https://repo.spring.io/milestone</url>
+			<snapshots>
+				<enabled>false</enabled>
+			</snapshots>
+		</pluginRepository>
+	</pluginRepositories>
 
 </project>

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -68,6 +68,14 @@ spring:
     import: "${SPRING_CONFIG_IMPORT:optional:file:./config/creds.yml}"
 
   ai:
+    model:
+      chat: openai
+      embedding: openai
+      image: none
+      moderation: none
+      audio:
+        speech: none
+        transcription: none
     openai:
       base-url: ${OPENAI_BASE_URL:https://api.groq.com/openai}
       chat:
@@ -87,6 +95,14 @@ spring:
     import: "${SPRING_CONFIG_IMPORT:optional:file:./config/creds.yml}"
 
   ai:
+    model:
+      chat: openai
+      embedding: openai
+      image: openai
+      moderation: openai
+      audio:
+        speech: openai
+        transcription: openai
     openai:
       audio:
         speech:
@@ -122,6 +138,11 @@ spring:
     model:
       chat: ollama
       embedding: ollama
+      image: none
+      moderation: none
+      audio:
+        speech: none
+        transcription: none
     ollama:
       base-url: ${OLLAMA_BASE_URL:http://localhost:11434}
       chat:


### PR DESCRIPTION
## Dependency Maintenance

### Java / JVM Version Changes

| Artifact | From | To | Notes |
|---|---|---|---|
| \`spring-boot-starter-parent\` | 4.0.1 | 4.1.0-RC1 | Transitively upgrades Spring Framework 7.0.7, Spring Security 7.1.0-RC1, Micrometer 1.17.0-RC1, OTel 1.60.1, Flyway 12.4.0 |
| \`spring-ai-bom\` | 2.0.0-M1 | 2.0.0-M7 | Researched all M1–M7 release notes; see assessment below |
| \`assertj-core\` | 3.27.6 | 3.27.7 | |
| \`jackson-databind-nullable\` | 0.2.8 | 0.2.10 | |
| \`json-io\` | 4.70.0 | 4.102.0 | |
| \`openapi-generator-maven-plugin\` | 7.18.0 | 7.22.0 | |
| \`spring-boot-hc5\` (httpclient5-actuator/resilience4j) | 2.0.0 | 2.0.1 | |
| \`spring-cloud-dependencies\` | 2025.1.0 | 2025.1.1 | |
| \`springdoc-openapi-starter-webmvc-ui\` | 3.0.1 | 3.0.3 | |

### Added Dependencies

| Artifact | Reason |
|---|---|
| \`spring-ai-starter-model-ollama\` | Missing — required for \`ollama\` Spring profile to provide a \`ChatModel\` bean |

### Removed Dependencies

| Artifact | Reason |
|---|---|
| \`spring-ai-spring-cloud-bindings\` | Eliminated in Spring AI 2.0.0-M7. \`org.springframework.cloud:spring-cloud-bindings\` (CF bindings) retained. |
| \`micrometer-bom\` (1.16.1 override) | Removed explicit pin; Spring Boot 4.1.0-RC1 manages 1.17.0-RC1 which supersedes the old override. |

### Skipped

| Artifact | Reason |
|---|---|
| \`cfenv\` 3.5.0 → 4.0.0 | Major version bump; API changes not assessed |
| \`frontend-maven-plugin\` | Versions plugin suggested downgrade to 1.11.3 — skipped |

### Repository Configuration

Added \`<pluginRepositories>\` entry for \`repo.spring.io/milestone\` so Maven can resolve \`spring-boot-maven-plugin:4.1.0-RC1\`.

### GitHub Actions Upgrades

| Action | From | To |
|---|---|---|
| \`actions/setup-java\` | v4 | v5 |
| \`actions/cache\` | v4 | v5 |

### Maven Wrapper Upgrade

\`3.9.9\` → \`3.9.16\`

### Documentation Updates

Updated Maven version references from \`3.9.9\` → \`3.9.16\` in:
- \`README.md\`
- \`docs/BUILD.md\`
- \`docs/CI.md\`
- \`docs/ARCHITECTURE.md\`

---

## Multi-Provider Spring AI Fix

### Root Cause (verified from bytecode)

All six OpenAI autoconfiguration classes use \`@ConditionalOnProperty(havingValue="openai", matchIfMissing=true)\`. The \`matchIfMissing=true\` means any **unset** model-type property silently defaults to creating an OpenAI bean. The \`ollama\` profile correctly set \`spring.ai.model.chat=ollama\` and \`spring.ai.model.embedding=ollama\`, but the four remaining types (\`image\`, \`moderation\`, \`audio.speech\`, \`audio.transcription\`) were never set — so Spring attempted to instantiate them without an API key:

```
Error creating bean 'openAiSdkAudioSpeechModel': At least one credential source
must be specified: credential (apiKey), workloadIdentity, or adminApiKey
```

### Fix: Explicit model selectors in every Spring profile (no Maven profiles needed)

All six \`spring.ai.model.*\` properties are now set explicitly in each provider profile block so no bean is ever created via the \`matchIfMissing\` fallback:

| Property | \`openai\` profile | \`ollama\` profile | \`groq-cloud\` profile |
|---|---|---|---|
| \`spring.ai.model.chat\` | \`openai\` | \`ollama\` | \`openai\` |
| \`spring.ai.model.embedding\` | \`openai\` | \`ollama\` | \`openai\` |
| \`spring.ai.model.image\` | \`openai\` | \`none\` | \`none\` |
| \`spring.ai.model.moderation\` | \`openai\` | \`none\` | \`none\` |
| \`spring.ai.model.audio.speech\` | \`openai\` | \`none\` | \`none\` |
| \`spring.ai.model.audio.transcription\` | \`openai\` | \`none\` | \`none\` |

\`groq-cloud\` disables image/moderation/audio because Groq does not expose those OpenAI-compatible endpoints.

---

## Spring AI M1 → M7 Breaking-Change Assessment

| Change | Milestone | Impact on this repo |
|---|---|---|
| \`spring-ai-spring-cloud-bindings\` eliminated | M7 | **Removed** from pom.xml |
| \`ChatOptions\` setters removed | M7 | No impact — options configured via YAML properties only |
| \`ToolCallAdvisor\` now default | M7 | No impact — \`SimpleLoggerAdvisor\` still available |
| SSE transport deprecated → Streamable HTTP | M7 | No impact — no MCP client usage |
| \`PromptChatMemoryAdvisor\` removed | M6 | No impact — not used |
| OpenAI*Properties no longer extend \`AbstractOpenAiOptions\` | M6 | No impact — no custom subclassing |
| All options setter methods removed (OpenAI, Anthropic, etc.) | M6 | No impact — YAML-configured only |
| \`ModelOptionsUtils.merge()\` eliminated | M5 | No impact — not called directly |
| \`spring-ai-azure-openai\` / \`spring-ai-vertex-ai-gemini\` removed | M5 | No impact — only using OpenAI starter |
| Jackson 3 (\`tools.jackson\`) now used | M3 | \`logging.level.tools.jackson\` already present in \`application.yml\` ✓ |
| \`McpAsyncClientCustomizer\`/\`McpSyncClientCustomizer\` → \`McpClientCustomizer<B>\` | M3 | No impact — no MCP customizer beans |
| \`disableMemory()\` → \`disableInternalConversationHistory()\` | M3 | No impact — not used |
| Claude 3 model enum constants removed | M3 | No impact — using OpenAI, not Anthropic |
| Default temperature constants removed | M1 | No impact — temperature not set programmatically |

## Spring Boot 4.1.0-RC1 Assessment

| Change | Impact on this repo |
|---|---|
| \`ReactorClientHttpRequestFactoryBuilder\` no longer applies \`proxyWithSystemProperties()\` | No impact — WebMVC (blocking), not reactive |
| New \`spring.datasource.connection-fetch\` (eager/lazy) | Informational; not needed |
| Spring Security 7.1.0-RC1 | No impact — Spring Security not directly configured |

---

## Consolidated Dependabot PRs

All 10 open Dependabot PRs closed with consolidation comment:

| PR | Artifact | Disposition |
|---|---|---|
| #87 | \`assertj-core\` 3.27.6 → 3.27.7 | Applied (bumped to 3.27.7) |
| #94 | \`spring-ai-bom\` 2.0.0-M2 | Superseded (bumped to 2.0.0-M7) |
| #96 | \`spring-cloud-dependencies\` 2025.1.1 | Applied |
| #97 | \`jackson-databind-nullable\` 0.2.9 | Applied (bumped to 0.2.10) |
| #98 | \`micrometer-bom\` 1.16.3 | Superseded (override removed; Boot 4.1 manages 1.17.0-RC1) |
| #101 | \`json-io\` 4.94.0 | Applied (bumped to 4.102.0) |
| #102 | \`openapi-generator-maven-plugin\` 7.20.0 | Applied (bumped to 7.22.0) |
| #103 | \`cfenv\` 4.0.0 | Closed — major bump, API changes not assessed |
| #104 | \`spring-boot-hc5\` 2.0.1 | Applied |
| #105 | \`spring-boot-starter-parent\` 4.0.3 | Superseded (bumped to 4.1.0-RC1) |

---

## Quality Gates

| Gate | Result |
|---|---|
| \`./mvnw compile\` | ✅ PASSED |
| \`./mvnw test\` (38 tests) | ✅ PASSED |
| App startup — \`ollama\` profile | ✅ Tomcat started on port 8080; quiz generation verified against Ollama |

## Security Alerts

GitHub reports 2 open Dependabot alerts (1 high, 1 moderate) on the default branch — pre-existing, not introduced by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)