### PR TITLE
fix: stop generating supporting pom.xml from openapi-generator

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -280,6 +280,16 @@
 						<configuration>
 							<inputSpec>${project.basedir}/src/main/resources/openapi/kahoot-openapiv3-spec.yml</inputSpec>
 							<generatorName>spring</generatorName>
+							<!--
+								Restrict supporting-file generation to the minimum required for interfaceOnly mode.
+								The default supporting-file pass also writes a standalone pom.xml that pins an
+								older spring-boot-starter-parent, which Snyk discovers as a separate project and
+								flags as vulnerable even though it is a non-deployed build artifact. ApiUtil.java
+								is the only supporting file the generated interfaces reference at compile time.
+							-->
+							<globalProperties>
+								<supportingFiles>ApiUtil.java</supportingFiles>
+							</globalProperties>
 							<configOptions>
 								<interfaceOnly>true</interfaceOnly>
 								<useJakartaEe>true</useJakartaEe>


### PR DESCRIPTION
## Summary

Eliminates the 38 Snyk findings that remained after #108 and #109 by stopping `openapi-generator-maven-plugin` from emitting the standalone `target/generated-sources/openapi/pom.xml` that Snyk was discovering as a third Maven project.

## Why #109 (`.snykignore`) didn't work

Snyk Open Source (`snyk test --all-projects`) doesn't honor `.snykignore` — that file is a Snyk Code (SAST) mechanism. Research (Snyk docs, 2025/2026) confirmed:

| Mechanism | Effect on `--all-projects` discovery |
|---|---|
| `.snykignore` | None (Snyk Code only) |
| `.snyk` policy `exclude: global:` | Only suppresses findings *after* discovery |
| `.snyk` policy `ignore:` | Requires explicit SNYK-IDs (38 of them, growing list) |
| `--exclude=target` CLI flag | Works, but every caller must remember it (local, CI, IDE) |
| **Don't generate the file** | **Removes the artifact entirely — no config exclusions needed** |

## Root cause

`openapi-generator-maven-plugin:7.22.0` runs a "supporting-file" template pass during `generate` that emits `pom.xml`, `README.md`, `openapi.yaml`, and `.openapi-generator/*` alongside the actual API interfaces and models. The generated `pom.xml` hardcodes its own parent:

```xml
<parent>
    <groupId>org.springframework.boot</groupId>
    <artifactId>spring-boot-starter-parent</artifactId>
    <version>3.3.13</version>
</parent>
```

This POM is a *standalone* Maven project — not a child module of the main project — so the main `pom.xml`'s `<tomcat.version>`, `<netty.version>`, and Spring Boot 4.1.0-RC1 parent never apply to it. Snyk dutifully resolves Spring Boot 3.3.13's transitive tree (Tomcat 10.1.42, Spring 6.1.21, Jackson 2.17.3, logback 1.5.18, spring-data-commons 3.3.13, etc.) and reports 38 CVEs against a file that is not deployed.

## The fix

Whitelist supporting files to just `ApiUtil.java` (the only one the generated API interfaces reference at compile time):

```xml
<globalProperties>
    <supportingFiles>ApiUtil.java</supportingFiles>
</globalProperties>
```

This is the documented openapi-generator mechanism — passing `--global-property supportingFiles=<csv>` as a whitelist. With it set, the generator skips `pom.xml`, `README.md`, `openapi.yaml`, `.openapi-generator/FILES`, etc. and only writes `ApiUtil.java` plus the regular `generateApis` / `generateModels` output.

`.snykignore` is retained as defense-in-depth for any future Snyk Code scans where excluding `target/` is semantically correct anyway.

## Test plan

- [x] `./mvnw -Pfly clean verify` — BUILD SUCCESS, 38 tests pass
- [x] `target/generated-sources/openapi/pom.xml` — confirmed absent
- [x] `target/generated-sources/openapi/.../ApiUtil.java` — confirmed present (compiles)
- [x] `snyk test --all-projects` — **2 projects tested, no vulnerable paths**

🤖 Generated with [Claude Code](https://claude.com/claude-code)